### PR TITLE
Add mysql to actions image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,4 +114,4 @@ RUN npm -v
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["yarn", "help"]
+CMD "yarn help"

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ RUN apt-get update && \
     libasound2 \
     xvfb \
     jq \
+    git \
  && rm -rf /var/lib/apt/lists/*
 
 # versions of local tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 # NOTE(don): this is a bit of a frankenstein, combining the mysql:5.7 Dockerfile
 # with the node:10.15.3-stretch-slim Dockerfile. They both have the same base,
-# so this should work
+# so this seems fine
 # https://github.com/docker-library/mysql/blob/bb7ea52db4e12d3fb526450d22382d5cd8cd41ca/5.7/Dockerfile
 FROM mysql:5.7.25
 
-### BEGIN: add bits from node:10.15.3-stretch-slim 
+# save the mysql command wrapper from the mysql package
+RUN cp \
+    /usr/local/bin/docker-entrypoint.sh \
+    /usr/local/bin/mysql-wrapper-for-docker.sh
+
+### BEGIN: add bits from node:10.15.3-stretch-slim
 # https://github.com/nodejs/docker-node/blob/170ed2092d4925971f9cd3ad5dfc416e820f90fd/10/stretch-slim/Dockerfile
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
@@ -69,7 +74,7 @@ RUN set -ex \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
   && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
   && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
-### END: add bits from node:10.15.3-stretch-slim 
+### END: add bits from node:10.15.3-stretch-slim
 
 LABEL version="1.1.0"
 LABEL repository="https://github.com/nuxt/actions-yarn"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,75 @@
-FROM node:10.13
+# NOTE(don): this is a bit of a frankenstein, combining the mysql:5.7 Dockerfile
+# with the node:10.15.3-stretch-slim Dockerfile. They both have the same base,
+# so this should work
+# https://github.com/docker-library/mysql/blob/bb7ea52db4e12d3fb526450d22382d5cd8cd41ca/5.7/Dockerfile
+FROM mysql:5.7.25
+
+### BEGIN: add bits from node:10.15.3-stretch-slim 
+# https://github.com/nodejs/docker-node/blob/170ed2092d4925971f9cd3ad5dfc416e820f90fd/10/stretch-slim/Dockerfile
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ENV NODE_VERSION 10.15.3
+
+RUN buildDeps='xz-utils' \
+    && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+      amd64) ARCH='x64';; \
+      ppc64el) ARCH='ppc64le';; \
+      s390x) ARCH='s390x';; \
+      arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
+      i386) ARCH='x86';; \
+      *) echo "unsupported architecture"; exit 1 ;; \
+    esac \
+    && set -ex \
+    && apt-get update && apt-get install -y ca-certificates curl wget gnupg dirmngr $buildDeps --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && for key in \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      77984A986EBC2AA786BC0F66B01FBB92821C587A \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && apt-get purge -y --auto-remove $buildDeps \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 1.13.0
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
+### END: add bits from node:10.15.3-stretch-slim 
 
 LABEL version="1.1.0"
 LABEL repository="https://github.com/nuxt/actions-yarn"
@@ -37,4 +108,4 @@ RUN npm -v
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["help"]
+CMD ["yarn", "help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN yarn config set unsafe-perm true
 # Taken from https://github.com/cypress-io/cypress-docker-images/blob/15c5bf875454a289e20587b192c4e4322787956c/base/10/Dockerfile#L3
 # BEGIN
 RUN apt-get update && \
-  apt-get install -y \
+  apt-get install --no-install-recommends -y \
     libgtk2.0-0 \
     libnotify-dev \
     libgconf-2-4 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,8 +9,4 @@ else
   echo "NPM_AUTH_TOKEN is not set"
 fi
 
-# startup mysql daemon
-mysqld &
-
-# just run whatever command was passed in
-sh -c "$*"
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,8 @@ else
   echo "NPM_AUTH_TOKEN is not set"
 fi
 
-sh -c "yarn $*"
+# startup mysql daemon
+mysqld &
+
+# just run whatever command was passed in
+sh -c "$*"

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -8,7 +8,7 @@ function setup() {
 }
 
 @test "entrypoint runs successfully" {
-  run $GITHUB_WORKSPACE/entrypoint.sh help
+  run $GITHUB_WORKSPACE/entrypoint.sh yarn help
   echo "$output"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
I'm not sure what the best way to go about this is, but it feels okay to just throw mysql into this docker image as well... If it becomes a problem (e.g. slate builds take too long pulling the image) I guess we can have separate node+mysql and only-node tags.

This also switches the Dockerfile setup so that users of this image need to provide a full command, e.g. `yarn run` instead of `run`. Seeing as this is a breaking change, if this gets merged I'll release it as 2.0.0